### PR TITLE
Fix cost calculation bug

### DIFF
--- a/build_exe.py
+++ b/build_exe.py
@@ -347,7 +347,10 @@ class CalculadoraCajas:
             dimensiones = self.calcular_dimensiones(largo, ancho, alto, ceja, tipo_codigo)
             
             # Cálculos financieros
-            costo_materia = (dimensiones['area'] * factor) / 10000
+            # El cálculo correcto se realiza sobre mil unidades de área
+            # para mantener consistencia con la versión ejecutada desde
+            # el código fuente (main.py) y la documentación.
+            costo_materia = (dimensiones['area'] * factor) / 1000
             precio_venta = costo_materia * utilidad
             precio_venta_ajustado = precio_venta * (1 + descuento / 100)
             ganancia_total = precio_venta_ajustado - costo_materia


### PR DESCRIPTION
## Summary
- correct financial calculation in build script to match documentation
- ensure build script ends with newline for POSIX compatibility

## Testing
- `python -m py_compile build_exe.py`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6840656e30c8832bb0af93e5bf1f2413